### PR TITLE
feat: ✨ add CLI to phzipcodes.py to run --scrape and specify --output

### DIFF
--- a/phzipcodes/scraper.py
+++ b/phzipcodes/scraper.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import json
 import logging
@@ -96,6 +97,8 @@ async def main(output_path: str | Path | None = None):
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description="A web scraper for zip codes")
+    parser.add_argument("-o", "--output", help="The output file path for data")
 
-# TODO: Make this a CLI tool
+    args = parser.parse_args()
+    asyncio.run(main(args.output))

--- a/phzipcodes/scraper.py
+++ b/phzipcodes/scraper.py
@@ -23,6 +23,7 @@ class ZipCode:
 
 
 BASE_URL = "https://phlpost.gov.ph/zip-code-locator/"
+DEFAULT_FILE = "ph_zip_codes.json"
 
 
 async def fetch_page(url: str) -> str:
@@ -74,7 +75,7 @@ def save_to_json(data: dict, filepath: str | Path | None = None):
     if filepath is None:
         data_dir = Path(__file__).parent / "data"
         data_dir.mkdir(parents=True, exist_ok=True)
-        filepath = data_dir / "ph_zip_codes.json"
+        filepath = data_dir / DEFAULT_FILE
     else:
         filepath = Path(filepath)
         filepath.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Usage:
`python phzipcodes.py --scrape`
`python phzipcodes.py --scrape -o result.json`

Was wondering how you would like to implement the scrape.py CLI. Should it be on that file or the main file. Posting here for initial idea if this works for you. Cheers.

Edit (03/01/25): 
Moved cli implementation to Scraper.py only. 
Usage:
`python -m phzipcodes.scraper`
`python -m phzipcodes.scraper --o ph_zip_codes.json
`python -m phzipcodes.scraper --output ph_zip_codes.json'
`python -m phzipcodes.scraper --o my_folder/ph_zip_codes.json`


